### PR TITLE
Update unlinking a Slack app

### DIFF
--- a/core/slack/class-edd-slack-api.php
+++ b/core/slack/class-edd-slack-api.php
@@ -229,8 +229,8 @@ class EDD_Slack_API {
 	 * @return  boolean Success/Failure
 	 */
 	public function revoke_oauth_token() {
-		
-		$oauth_revoke = $this->post(
+
+		$oauth_revoke = $this->get(
 			'auth.revoke'
 		);
 

--- a/core/slack/class-edd-slack-api.php
+++ b/core/slack/class-edd-slack-api.php
@@ -11,13 +11,13 @@
 defined( 'ABSPATH' ) || die();
 
 class EDD_Slack_API {
-	
+
 	/**
 	 * @var			EDD_Slack_API $oauth_token Authenticates requests for the Slack App Integration
 	 * @since		1.0.0
 	 */
 	private $oauth_token = '';
-	
+
 	/**
 	 * @var			EDD_Slack_API $api_endpoint Slack's Web API Endpoint. This is only used for Slack App Integration
 	 * @since		1.0.0
@@ -30,20 +30,20 @@ class EDD_Slack_API {
 	 * @since 1.0.0
 	 */
 	function __construct() {
-		
+
 		$oauth_token = edd_get_option( 'slack_app_oauth_token', false );
-		
+
 		// Default to an empty string
 		$this->oauth_token = ( $oauth_token && $oauth_token !== '-1' ) ? $oauth_token : '';
-		
+
 	}
-	
+
 	/**
 	 * Push an "incoming webhook" to Slack.
-	 * 
+	 *
 	 * @param		string 	$hook  	Webhook URL
 	 * @param		array	$args	Assoc array of arguments to send to Slack
-	 *																
+	 *
 	 * @access		public
 	 * @since		1.0.0
 	 * @return		array 			API Response
@@ -66,16 +66,16 @@ class EDD_Slack_API {
 		) );
 
 		return $result;
-		
+
 	}
 
 	/**
 	 * Make an HTTP DELETE request - for deleting data
-	 * 
+	 *
 	 * @param		string $method  	URL of the API request method
 	 * @param		array	$args		Assoc array of arguments (if any)
 	 * @param		int 	$timeout	Timeout limit for request in seconds
-	 *																
+	 *
 	 * @access		public
 	 * @since		1.0.0
 	 * @return		array|false 		Assoc array of API response, decoded from JSON
@@ -83,14 +83,14 @@ class EDD_Slack_API {
 	public function delete( $method, $args = array(), $timeout = 10 ) {
 		return $this->make_request( 'DELETE', $method, $args, $timeout );
 	}
-	
+
 	/**
 	 * Make an HTTP GET request - for retrieving data
-	 * 
+	 *
 	 * @param		string 	$method  	URL of the API request method
 	 * @param		array	$args		Assoc array of arguments (if any)
 	 * @param		int 	$timeout	Timeout limit for request in seconds
-	 *																
+	 *
 	 * @access		public
 	 * @since		1.0.0
 	 * @return		array|false 		Assoc array of API response, decoded from JSON
@@ -98,14 +98,14 @@ class EDD_Slack_API {
 	public function get( $method, $args = array(), $timeout = 10 ) {
 		return $this->make_request( 'GET', $method, $args, $timeout );
 	}
-	
+
 	/**
 	 * Make an HTTP PATCH request - for performing partial updates
-	 * 
+	 *
 	 * @param		string 	$method  	URL of the API request method
 	 * @param		array	$args		Assoc array of arguments (if any)
 	 * @param		int 	$timeout	Timeout limit for request in seconds
-	 *																
+	 *
 	 * @access		public
 	 * @since		1.0.0
 	 * @return		array|false			Assoc array of API response, decoded from JSON
@@ -113,14 +113,14 @@ class EDD_Slack_API {
 	public function patch( $method, $args = array(), $timeout = 10 ) {
 		return $this->make_request( 'PATCH', $method, $args, $timeout );
 	}
-	
+
 	/**
 	 * Make an HTTP POST request - for creating and updating items
-	 * 
+	 *
 	 * @param		string 	$method  	URL of the API request method
 	 * @param		array	$args		Assoc array of arguments (if any)
 	 * @param		int 	$timeout	Timeout limit for request in seconds
-	 *																
+	 *
 	 * @access		public
 	 * @since		1.0.0
 	 * @return		array|false			Assoc array of API response, decoded from JSON
@@ -128,14 +128,14 @@ class EDD_Slack_API {
 	public function post( $method, $args = array(), $timeout = 10 ) {
 		return $this->make_request( 'POST', $method, $args, $timeout );
 	}
-	
+
 	/**
 	 * Make an HTTP PUT request - for creating new items
-	 * 
+	 *
 	 * @param		string 	$method  	URL of the API request method
 	 * @param		array	$args		Assoc array of arguments (if any)
 	 * @param		int 	$timeout	Timeout limit for request in seconds
-	 *																
+	 *
 	 * @access		public
 	 * @since		1.0.0
 	 * @return		array|false			Assoc array of API response, decoded from JSON
@@ -145,107 +145,104 @@ class EDD_Slack_API {
 	}
 	/**
 	 * Performs the underlying HTTP request
-	 * 
-	 * @param		string 	$http_verb  The HTTP verb to use: get, post, put, patch, delete
-	 * @param		string	$method		The API method to be called
-	 * @param		array 	$args		Assoc array of parameters to be passed
-	 * @param		integer $timeout 	Timeout limit for request in seconds
-	 *																
-	 * @access		public
-	 * @since		1.0.0
-	 * @return		array|false 		Assoc array of API response, decoded from JSON
+	 *
+	 * @param string  $http_verb  The HTTP verb to use: get, post, put, patch, delete
+	 * @param string  $method     The API method to be called
+	 * @param array   $args       Assoc array of parameters to be passed
+	 * @param integer $timeout    Timeout limit for request in seconds
+	 *
+	 * @access public
+	 * @since  1.0.0
+	 * @return array|false Assoc array of API response, decoded from JSON
 	 */
 	private function make_request( $http_verb, $method, $args = array(), $timeout = 10 ) {
-		
+
 		$args = wp_parse_args( $args, array(
-			'method' => $http_verb,
+			'method'  => $http_verb,
 			'timeout' => $timeout,
 			'headers' => array(),
 		) );
 
 		$url = $this->api_endpoint . '/' . $method;
-		
-		// This same function is used for granting OAUTH access
-		if ( $this->oauth_token !== '' ) {
-			$url = add_query_arg( 'token', $this->oauth_token, $url );
+
+		// Add the authorization header if the oauth token exists.
+		if ( ! empty( $this->oauth_token ) ) {
+			$args['headers']['Authorization'] = 'Bearer ' . $this->oauth_token;
 		}
 
 		$response = wp_remote_request( $url, $args );
-		return json_decode( $response['body'] );
 
+		return json_decode( $response['body'] );
 	}
-	
+
 	/**
 	 * Encode $args for being passed as GET parameters for the Slack Web API
-	 * 
+	 *
 	 * @param		array $args Notification Arguments
-	 *										
+	 *
 	 * @access		public
 	 * @since		1.0.0
 	 * @return		array 		Transformed Notification Arguments
 	 */
 	public function encode_arguments( $args ) {
-		
+
 		foreach ( $args as $key => $value ) {
-			
+
 			if ( empty( $value ) ) {
 				unset( $args[ $key ] );
 				continue;
 			}
-			
+
 			if ( is_array( $value ) ) {
 				$value = json_encode( $value );
 			}
-			
+
 			$args[ $key ] = urlencode_deep( $value );
-			
+
 		}
-		
+
 		return $args;
-		
+
 	}
-	
+
 	/**
 	 * Set the OAUTH Token for the Object
-	 * 
+	 *
 	 * @param		string $oauth_token Slack API OAUTH Token
-	 *											
+	 *
 	 * @access		public
 	 * @since		1.0.0
 	 * @return		void
 	 */
 	public function set_oauth_token( $oauth_token ) {
-		
+
 		edd_update_option( 'slack_app_oauth_token', $oauth_token );
 		$this->oauth_token = $oauth_token;
-		
+
 	}
-	
+
 	/**
 	 * Revoke the OAUTH Token for the Object
-	 * 
-	 * @access		public
-	 * @since		1.0.0
-	 * @return		boolean Success/Failure
+	 *
+	 * @access  public
+	 * @since   1.0.0
+	 * @return  boolean Success/Failure
 	 */
 	public function revoke_oauth_token() {
 		
 		$oauth_revoke = $this->post(
 			'auth.revoke'
 		);
-		
+
 		if ( $oauth_revoke->ok ) {
-		
+
 			edd_delete_option( 'slack_app_oauth_token' );
 			$this->oauth_token = '';
-			
+
 			return $oauth_revoke->revoked;
-			
-		}
-		else {
+
+		} else {
 			return false;
 		}
-		
 	}
-
 }

--- a/core/ssl-only/class-edd-slack-app-oauth-settings.php
+++ b/core/ssl-only/class-edd-slack-app-oauth-settings.php
@@ -344,16 +344,10 @@ class EDD_Slack_OAUTH_Settings {
 		}
 
 		$code       = isset( $_GET['code'] ) ? sanitize_text_field( $_GET['code'] ) : false;
-		// $_GET['section'] is set properly by our redirect_uri
 		$section    = isset( $_GET['section'] ) && 'edd-slack-settings' === $_GET['section'];
-
-		if ( ! $code || ! $section ) {
-			return;
-		}
-		// $_GET['state'] is set by the JavaScript for the OAUTH2 Popup
-		$state      = isset( $_GET['state'] ) ? sanitize_text_field( $_GET['state'] ) : false;
 		$token_type = isset( $_GET['token_type'] ) ? sanitize_text_field( $_GET['token_type'] ) : false;
-		if ( 'saving' !== $state || ! $token_type ) {
+
+		if ( ! $code || ! $section || ! $token_type ) {
 			return;
 		}
 
@@ -366,6 +360,7 @@ class EDD_Slack_OAUTH_Settings {
 			),
 			admin_url( 'edit.php' )
 		);
+
 		// If we need to get an OAUTH Token
 		if ( ( ! $this->is_authorized() && 'main' === $token_type ) || ( ! edd_get_option( 'slack_app_has_client_scope' ) && 'team_invites' === $token_type ) ) {
 
@@ -387,7 +382,7 @@ class EDD_Slack_OAUTH_Settings {
 				$redirect_uri = add_query_arg(
 					array(
 						'edd_slack_oauth' => 'fail',
-						'edd_slack_type' => 'error',
+						'edd_slack_type'  => 'error',
 					),
 					$redirect_uri
 				);

--- a/core/ssl-only/class-edd-slack-app-oauth-settings.php
+++ b/core/ssl-only/class-edd-slack-app-oauth-settings.php
@@ -221,7 +221,7 @@ class EDD_Slack_OAUTH_Settings {
 					'https://slack.com/oauth/authorize'
 				);
 				?>
-				<a href="<?php echo $slack_uri; ?>" target="_self" class="edd-slack-app-auth button button-primary" data-token_type="main">
+				<a href="<?php echo esc_url( $slack_uri ); ?>" target="_self" class="edd-slack-app-auth button button-primary" data-token_type="main">
 					<?php esc_html_e( 'Link Slack App', 'edd-slack' ); ?>
 				</a>
 
@@ -397,6 +397,7 @@ class EDD_Slack_OAUTH_Settings {
 				);
 
 				wp_safe_redirect( $redirect_uri );
+				exit;
 			}
 
 			$oauth_token = $oauth_request->access_token;
@@ -424,6 +425,7 @@ class EDD_Slack_OAUTH_Settings {
 				);
 			}
 			wp_safe_redirect( $redirect_uri );
+			exit;
 		}
 	}
 

--- a/core/ssl-only/class-edd-slack-app-oauth-settings.php
+++ b/core/ssl-only/class-edd-slack-app-oauth-settings.php
@@ -331,11 +331,11 @@ class EDD_Slack_OAUTH_Settings {
 	}
 
 	/**
-	 * Store the OAUTH Access Token after the Temporary Code is received
+	 * Store the OAUTH Access Token after the Temporary Code is received.
 	 *
-	 * @access		  public
-	 * @since		  1.0.0
-	 * @return		  void
+	 * @access public
+	 * @since  1.0.0
+	 * @return void
 	 */
 	public function store_oauth_token() {
 
@@ -343,11 +343,20 @@ class EDD_Slack_OAUTH_Settings {
 			return;
 		}
 
-		$code       = isset( $_GET['code'] ) ? sanitize_text_field( $_GET['code'] ) : false;
-		$section    = isset( $_GET['section'] ) && 'edd-slack-settings' === $_GET['section'];
+		// Return if this is not the EDD Slack Settings screen.
+		$section = isset( $_GET['section'] ) && 'edd-slack-settings' === $_GET['section'];
+		if ( ! $section ) {
+			return;
+		}
+
+		// The code provided by Slack.
+		$code = isset( $_GET['code'] ) ? sanitize_text_field( $_GET['code'] ) : false;
+
+		// The token type to validate (should be `main` or `team_invites`).
 		$token_type = isset( $_GET['token_type'] ) ? sanitize_text_field( $_GET['token_type'] ) : false;
 
-		if ( ! $code || ! $section || ! $token_type ) {
+		// Return if the code is missing or the token type is missing.
+		if ( ! $code || ! $token_type ) {
 			return;
 		}
 

--- a/core/ssl-only/class-edd-slack-app-oauth-settings.php
+++ b/core/ssl-only/class-edd-slack-app-oauth-settings.php
@@ -471,21 +471,22 @@ class EDD_Slack_OAUTH_Settings {
 	 */
 	public function display_admin_notices() {
 
+		$section = ! empty( $_GET['section'] ) && 'edd-slack-settings' === $_GET['section'];
+		$message = ! empty( $_GET['edd_slack_oauth'] ) ? $this->get_oauth_message( $_GET['edd_slack_oauth'] ) : false;
+		if ( empty( array_filter( $this->admin_notices ) ) && $section && $message ) {
+			$this->admin_notices[] = array(
+				'edd-notices',
+				'edd_slack_app_auth',
+				esc_html( $message ),
+				esc_attr( $_GET['edd_slack_type'] ),
+			);
+		}
+
 		foreach ( $this->admin_notices as $admin_notice ) {
 
 			// Pass array as Function Parameters
 			call_user_func_array( 'add_settings_error', $admin_notice );
 
-		}
-
-		$section = ! empty( $_GET['section'] ) && 'edd-slack-settings' === $_GET['section'];
-		$message = ! empty( $_GET['edd_slack_oauth'] ) ? $this->get_oauth_message( $_GET['edd_slack_oauth'] ) : false;
-		if ( $section && $message ) {
-			?>
-			<div class="<?php echo esc_attr( $_GET['edd_slack_type'] ); ?>">
-			<p><?php echo esc_html( $message ); ?></p>
-			</div>
-			<?php
 		}
 
 		// Clear out Notices

--- a/core/ssl-only/class-edd-slack-app-oauth-settings.php
+++ b/core/ssl-only/class-edd-slack-app-oauth-settings.php
@@ -11,7 +11,7 @@
 defined( 'ABSPATH' ) || die();
 
 class EDD_Slack_OAUTH_Settings {
-	
+
 	/**
 	 * @var		 EDD_Slack_OAUTH_Settings $admin_notices Allows Admin Notices to be ran when possible despite our Hook
 	 * @since	  1.0.0
@@ -24,41 +24,41 @@ class EDD_Slack_OAUTH_Settings {
 	 * @since 1.0.0
 	 */
 	function __construct() {
-		
+
 		// Add SSL-only settings for OAUTH
 		add_filter( 'edd_slack_settings', array( $this, 'add_oauth_settings' ) );
-		
+
 		// Display which Triggers support Interactive Notifications
 		add_action( 'edd_slack_interactive_notification_support', array( $this, 'add_interactive_button_support_list' ) );
-		
+
 		// Add the OAUTH Registration Button
 		add_action( 'edd_slack_oauth_register', array( $this, 'add_oauth_registration_button' ) );
-		
+
 		// Add the OAUTH Registration Button for Slack Team Invites
 		add_action( 'edd_slack_invites_oauth_register', array( $this, 'add_slack_invites_oauth_register' ) );
-		
+
 		// Grab the OAUTH Key as part of the handshake process
 		add_action( 'init', array( $this, 'store_oauth_token' ) );
-		
+
 		// Delete the OAUTH Key
 		add_action( 'init', array( $this, 'delete_oauth_token' ) );
-		
+
 		// Display Admin Notices
 		add_action( 'admin_init', array( $this, 'display_admin_notices' ) );
-		
+
 	}
-	
+
 	/**
 	 * Add our OAUTH Settings Fields only if we have SSL
-	 * 
+	 *
 	 * @param	  array $settings EDD Slack Settings Fields
-	 *												 
+	 *
 	 * @access	  public
 	 * @since	  1.0.0
 	 * @return	  array Modified Settings Fields
 	 */
 	public function add_oauth_settings( $settings ) {
-		
+
 		$oauth_settings = apply_filters( 'edd_slack_oauth_settings', array(
 			array(
 				'type' => 'header',
@@ -104,45 +104,45 @@ class EDD_Slack_OAUTH_Settings {
 				)
 			),
 		) );
-		
+
 		$settings = array_merge( $settings, $oauth_settings );
-		
+
 		return $settings;
-		
+
 	}
-	
+
 	/**
 	 * Show a list of Triggers that support Interactive Notifications
-	 * 
+	 *
 	 * @param	  array $args EDD Settings API $args
-	 *										  
+	 *
 	 * @access	  public
 	 * @since	  1.0.0
 	 * @return	  void
 	 */
 	public function add_interactive_button_support_list( $args ) {
-		
+
 		$triggers = EDDSLACK()->get_slack_triggers();
-		
+
 		$interactive_triggers = apply_filters( 'edd_slack_interactive_triggers', array() );
-		
+
 		sort( $interactive_triggers );
-		
+
 		if ( ! empty ( $interactive_triggers ) ) {
-			
+
 			// Holds HTML representation of Triggers that Support Interactive Notifications
 			$supported = array();
-			
+
 			foreach ( $triggers as $trigger => $label ) {
-				
+
 				if ( in_array( $trigger, $interactive_triggers ) ) {
-					
+
 					$supported[] = '<li>' . $label . '</li>';
-					
+
 				}
-				
+
 			}
-			
+
 			ob_start();
 			?>
 
@@ -150,33 +150,33 @@ class EDD_Slack_OAUTH_Settings {
 				<?php echo implode( '', $supported ); ?>
 			</ul>
 
-			<?php 
-			
+			<?php
+
 			$supported_list = ob_get_clean();
-			
+
 			printf( _x( 'The following Triggers support Interactive Notifications on your Site: %s', 'Triggers Supporting Interactive Notifications Text', 'edd-slack' ), $supported_list );
-			
+
 		}
 		else {
 			echo _x( 'None of available Triggers on your Site currently provide support for Interactive Notifications, but you will still have access to the included Slash Commands by linking a Slack App!', 'No Triggers Supporting Interactive Notifications Text', 'edd-slack' );
 		}
-		
+
 	}
-	
+
 	/**
 	 * Adds our Button Link to Authorize/Deauthorize the Slack App
-	 * 
+	 *
 	 * @param	  array $args EDD Settings API $args
-	 *										  
+	 *
 	 * @access	  public
 	 * @since	  1.0.0
 	 * @return	  void
 	 */
 	public function add_oauth_registration_button( $args ) {
-		
+
 		$client_id = edd_get_option( 'slack_app_client_id' );
 		$client_secret = edd_get_option( 'slack_app_client_secret' );
-		
+
 		/**
 		 * In case Scope needs to be changed by 3rd Party Integrations
 		 *
@@ -187,18 +187,18 @@ class EDD_Slack_OAUTH_Settings {
 			'users:read',
 			'commands',
 		) );
-		
+
 		$scope = implode( ',', $scope );
-		
+
 		$redirect_uri = urlencode_deep( admin_url( 'edit.php?post_type=download&page=edd-settings&tab=extensions&section=edd-slack-settings' ) );
-		
-		if ( $client_id && $client_secret ) : 
-		
+
+		if ( $client_id && $client_secret ) :
+
 			$oauth_token = edd_get_option( 'slack_app_oauth_token', false );
 
-			if ( ! $oauth_token || 
+			if ( ! $oauth_token ||
 			   $oauth_token == '-1' ) : ?>
-			
+
 				<a href="//slack.com/oauth/authorize?client_id=<?php echo $client_id; ?>&scope=<?php echo $scope; ?>&redirect_uri=<?php echo $redirect_uri; ?>" target="_self" class="edd-slack-app-auth button button-primary" data-token_type="main">
 					<?php echo _x( 'Link Slack App', 'OAUTH Register Buton Label', 'edd-slack' ); ?>
 				</a>
@@ -208,31 +208,31 @@ class EDD_Slack_OAUTH_Settings {
 				<input type="submit" name="edd_slack_app_deauth" class="button" value="<?php echo _x( 'Unlink Slack App', 'OAUTH Deregister Button Label', 'edd-slack' ); ?>" data-token_type="main" />
 
 			<?php endif; ?>
-			
+
 		<?php else : ?>
 
 			<p class="description">
 				<?php echo _x( 'Fill out the above fields and Save the Settings to Connect your Slack App to your site.', 'OAUTH Registration Help Text', 'edd-slack' ); ?>
 			</p>
-		
+
 		<?php endif;
-		
+
 	}
-	
+
 	/**
 	 * Adds our Button Link to Authorize/Deauthorize the Slack App for Inviting Users to the Team
-	 * 
+	 *
 	 * @param	  array $args EDD Settings API $args
-	 *										  
+	 *
 	 * @access	  public
 	 * @since	  1.1.0
 	 * @return	  void
 	 */
 	public function add_slack_invites_oauth_register( $args ) {
-		
+
 		$client_id = edd_get_option( 'slack_app_client_id' );
 		$client_secret = edd_get_option( 'slack_app_client_secret' );
-		
+
 		/**
 		 * Most other scopes are not compatible with "client", but just in case
 		 *
@@ -241,17 +241,17 @@ class EDD_Slack_OAUTH_Settings {
 		$scope = apply_filters( 'edd_slack_app_team_invites_scope', array(
 			'client',
 		) );
-		
+
 		$scope = implode( ',', $scope );
-		
+
 		$redirect_uri = urlencode_deep( admin_url( 'edit.php?post_type=download&page=edd-settings&tab=extensions&section=edd-slack-settings' ) );
-		
+
 		$oauth_token = edd_get_option( 'slack_app_oauth_token', false );
 		$granted_client_scope = edd_get_option( 'slack_app_has_client_scope' );
-		
-		if ( $client_id && $client_secret ) : 
 
-			if ( ! $oauth_token || 
+		if ( $client_id && $client_secret ) :
+
+			if ( ! $oauth_token ||
 			   $oauth_token == '-1' ) : ?>
 
 				<p class="description">
@@ -259,7 +259,7 @@ class EDD_Slack_OAUTH_Settings {
 				</p>
 
 			<?php elseif ( ! $granted_client_scope ) : ?>
-			
+
 				<a href="//slack.com/oauth/authorize?client_id=<?php echo $client_id; ?>&scope=<?php echo $scope; ?>&redirect_uri=<?php echo $redirect_uri; ?>" target="_self" class="edd-slack-app-auth button button-primary" data-token_type="team_invites">
 					<?php echo _x( 'Allow Slack App to Invite Users to your Team', 'OAUTH Register Team Invites Buton Label', 'edd-slack' ); ?>
 				</a>
@@ -269,47 +269,47 @@ class EDD_Slack_OAUTH_Settings {
 				<input type="submit" name="edd_slack_app_deauth" class="button" value="<?php echo _x( 'Unlink Slack App', 'OAUTH Deregister Button Label', 'edd-slack' ); ?>" data-token_type="team_invites" />
 
 			<?php endif; ?>
-			
+
 		<?php else : ?>
 
 			<p class="description">
 				<?php echo _x( 'Fill out the above fields and Save the Settings to Connect your Slack App to your site.', 'OAUTH Registration Help Text', 'edd-slack' ); ?>
 			</p>
-		
+
 		<?php endif;
-		
+
 	}
-	
+
 	/**
 	 * Store the OAUTH Access Token after the Temporary Code is received
-	 * 
+	 *
 	 * @access		  public
 	 * @since		  1.0.0
 	 * @return		  void
 	 */
 	public function store_oauth_token() {
-		
+
 		if ( ! is_admin() ) return false;
-		
+
 		$oauth_token = edd_get_option( 'slack_app_oauth_token', false );
-		
+
 		// If we need to get an OAUTH Token
 		// $_GET['state'] is set by the JavaScript for the OAUTH2 Popup
 		// $_GET['section'] is set properly by our redirect_uri
-		if ( isset( $_GET['code'] ) && 
-			isset( $_GET['state'] ) && 
-			$_GET['state'] == 'saving' && 
+		if ( isset( $_GET['code'] ) &&
+			isset( $_GET['state'] ) &&
+			$_GET['state'] == 'saving' &&
 			isset( $_GET['token_type'] ) &&
-			isset( $_GET['section'] ) && 
-			$_GET['section'] == 'edd-slack-settings' && 
-			( ( ! $oauth_token || $oauth_token == '-1' ) && $_GET['token_type'] == 'main' || 
+			isset( $_GET['section'] ) &&
+			$_GET['section'] == 'edd-slack-settings' &&
+			( ( ! $oauth_token || $oauth_token == '-1' ) && $_GET['token_type'] == 'main' ||
 			 ! edd_get_option( 'slack_app_has_client_scope' ) && $_GET['token_type'] == 'team_invites' ) ) {
-			
+
 			$client_id = edd_get_option( 'slack_app_client_id' );
 			$client_secret = edd_get_option( 'slack_app_client_secret' );
-		
+
 			$redirect_uri = urlencode_deep( admin_url( 'edit.php?post_type=download&page=edd-settings&tab=extensions&section=edd-slack-settings' ) );
-			
+
 			$oauth_access_url = add_query_arg(
 				array(
 					'client_id' => $client_id,
@@ -319,98 +319,108 @@ class EDD_Slack_OAUTH_Settings {
 				),
 				'oauth.access'
 			);
-			
-			$oauth_request = EDDSLACK()->slack_api->post( 
+
+			$oauth_request = EDDSLACK()->slack_api->post(
 				$oauth_access_url
 			);
-			
+
 			if ( $oauth_request->ok == 'true' ) {
-				
+
 				$oauth_token = $oauth_request->access_token;
 				EDDSLACK()->slack_api->set_oauth_token( $oauth_token );
-				
+
 				if ( $_GET['token_type'] == 'main' ) {
-				
+
 					$this->admin_notices[] = array(
 						'edd-notices',
 						'edd_slack_app_auth',
 						_x( 'Slack App Linked Successfully.', 'EDD Slack App Auth Successful', 'edd-slack' ),
 						'updated'
 					);
-					
+
 				}
 				else if ( $_GET['token_type'] == 'team_invites' ) {
-					
+
 					$granted_client_scope = edd_update_option( 'slack_app_has_client_scope', true );
-					
+
 					$this->admin_notices[] = array(
 						'edd-notices',
 						'edd_slack_app_team_invites_auth',
 						_x( 'Slack App Team Invites Enabled Successfully.', 'EDD Slack App Team Invites Auth Successful', 'edd-slack' ),
 						'updated'
 					);
-					
+
 				}
-				
+
 			}
-			
+
 		}
-		
+
 	}
-	
+
 	/**
 	 * Revoke the OAUTH Token
-	 * 
-	 * @access	  public
-	 * @since	  1.0.0
-	 * @return	  void
+	 *
+	 * @access  public
+	 * @since   1.0.0
+	 * @return  void
 	 */
 	public function delete_oauth_token() {
-		
+
 		// For some reason we can't hook into admin_init within a production environment. Yeah, I have no idea either
 		// It only effects DELETING things from wp_options. Storing works just fine.
-		if ( is_admin() ) {
-			
-			if ( isset( $_POST['edd_slack_app_deauth'] ) ) {
-
-				EDDSLACK()->slack_api->revoke_oauth_token();
-				
-				$revoked_client_scope = edd_delete_option( 'slack_app_has_client_scope' );
-				
-				delete_transient( 'edd_slack_channels_list' );
-
-				$this->admin_notices[] = array(
-					'edd-notices',
-					'edd_slack_app_deauth',
-					_x( 'Slack App Unlinked Successfully.', 'EDD Slack App Deauth Successful', 'edd-slack' ),
-					'updated'
-				);
-
-			}
-			
+		if ( ! is_admin() || ! current_user_can( 'manage_options' ) ) {
+			return;
 		}
-		
+
+		if ( ! isset( $_POST['edd_slack_app_deauth'] ) ) {
+			return;
+		}
+
+		$revoked = EDDSLACK()->slack_api->revoke_oauth_token();
+
+		if ( ! $revoked ) {
+			$this->admin_notices[] = array(
+				'edd-notices',
+				'edd_slack_app_deauth',
+				_x( 'The Slack App could not be unlinked.', 'EDD Slack App Deauth Not Successful', 'edd-slack' ),
+				'error',
+			);
+
+			return;
+		}
+
+		$revoked_client_scope = edd_delete_option( 'slack_app_has_client_scope' );
+
+		delete_transient( 'edd_slack_channels_list' );
+
+		$this->admin_notices[] = array(
+			'edd-notices',
+			'edd_slack_app_deauth',
+			_x( 'Slack App Unlinked Successfully.', 'EDD Slack App Deauth Successful', 'edd-slack' ),
+			'updated',
+		);
 	}
-	
+
 	/**
 	 * Sometimes we need to add Admin Notices when add_settings_error() isn't accessable yet
-	 * 
+	 *
 	 * @access	  public
 	 * @since	  1.0.0
 	 * @return	  void
 	 */
 	public function display_admin_notices() {
-			
+
 		foreach( $this->admin_notices as $admin_notice ) {
-			
+
 			// Pass array as Function Parameters
 			call_user_func_array( 'add_settings_error', $admin_notice );
-			
+
 		}
-		
+
 		// Clear out Notices
 		$this->admin_notices = array();
-		
+
 	}
-	
+
 }


### PR DESCRIPTION
Fixes #131 

Proposed changes:
1. Send the oAuth token as an `Authorization` header instead of appending to the URL.
2. Use `GET` instead of `POST` for revoking.
3. Restrict revoking to administrator level users, and update the logic in that function to be a little more readable.
4. When viewing the settings screen for the extension, send a quick authorization check to Slack to see if the token is still valid. If it's not, delete the setting.
5. Rework the logic for setting the oAuth token--a bit more verbose but easier to read for me.