### PR TITLE
Update load priority, FES check

### DIFF
--- a/edd-slack.php
+++ b/edd-slack.php
@@ -396,18 +396,14 @@ if ( ! class_exists( 'EDD_Slack' ) ) {
 			// If EDD FES is Active
 			if ( class_exists( 'EDD_Front_End_Submissions' ) ) {
 
-				if ( defined( 'fes_plugin_version' ) &&
-				  version_compare( fes_plugin_version, '2.4.2' ) >= 0 ) {
+				if ( defined( 'fes_plugin_version' ) && version_compare( fes_plugin_version, '2.4.2', '>=' ) ) {
 
 					require_once EDD_Slack_DIR . '/core/integrations/edd-frontend-submissions/class-edd-slack-frontend-submissions.php';
 
-				}
-				else {
+				} else {
 
 					$this->integration_errors[] = sprintf( _x( '%s includes features which integrate with %s, but v%s or greater of %s is required.', 'Outdated Integration Error', 'edd-slack' ), '<strong>' . $this->plugin_data['Name'] . '</strong>', '<a href="' . admin_url( 'update-core.php' ) . '"><strong>Easy Digital Downloads - Frontend Submissions</strong></a>', '2.4.2', '<a href="' . admin_url( 'update-core.php' ) . '"><strong>Easy Digital Downloads - Frontend Submissions</strong></a>' );
-
 				}
-
 			}
 
 			// If EDD Commissions is Active
@@ -959,10 +955,10 @@ if ( ! class_exists( 'EDD_Slack' ) ) {
  * The main function responsible for returning the one true EDD_Slack
  * instance to functions everywhere
  *
- * @since	  1.0.0
- * @return	  \EDD_Slack The one true EDD_Slack
+ * @since   1.0.0
+ * @return  \EDD_Slack The one true EDD_Slack
  */
-add_action( 'plugins_loaded', 'EDD_Slack_load' );
+add_action( 'plugins_loaded', 'EDD_Slack_load', 100 );
 function EDD_Slack_load() {
 
 	if ( ! class_exists( 'Easy_Digital_Downloads' ) ) {
@@ -974,8 +970,7 @@ function EDD_Slack_load() {
 		$activation = new EDD_Extension_Activation( plugin_dir_path( __FILE__ ), basename( __FILE__ ) );
 		$activation = $activation->run();
 
-	}
-	else {
+	} else {
 
 		require_once __DIR__ . '/core/edd-slack-functions.php';
 		EDDSLACK();


### PR DESCRIPTION
Fixes #127

Proposed changes:
1. Make the `EDD_Slack_load` function run later on `plugins_loaded` so that the FES version is defined.
2. Update the `version_compare` to use the comparison operator as the third parameter.

To test:
Make sure FES is active. On master, when you visit the Slack extension settings page, an admin notice will display which suggests that your version of FES is not current enough to work with Slack, even though it is. With this branch, the notice should not display.

Interestingly, it seems like this would have prevented the FES integration from working at all?