### PR TITLE
Update auto-invites channels list retrieval

### DIFF
--- a/core/ssl-only/slack-invites/class-edd-slack-app-invites-settings.php
+++ b/core/ssl-only/slack-invites/class-edd-slack-app-invites-settings.php
@@ -11,42 +11,39 @@
 defined( 'ABSPATH' ) || die();
 
 class EDD_Slack_Invites_Settings {
-	
+
 	/**
 	 * @var		 EDD_Slack_OAUTH_Settings $general_channel If we know what the renamed General Channel is, use it instead
 	 * @since	  1.1.0
 	 */
 	public $general_channel = 'general';
-	
+
 	/**
 	 * EDD_Slack_Invites_Settings constructor.
 	 *
 	 * @since 1.0.0
 	 */
 	function __construct() {
-		
-		// Updates our $general_channel and sets/updates our Transient
-		add_action( 'admin_init', array( $this, 'get_public_channels' ) );
-		
+
 		// Adds our Slack Team Invite Settings
 		add_filter( 'edd_slack_oauth_settings', array( $this, 'add_slack_invites_settings' ) );
-		
+
 		// Updates #general Channel in other places
 		add_filter( 'edd_slack_general_channel', array( $this, 'update_general_channel' ) );
-		
+
 	}
-	
+
 	/**
 	 * Adds the Slack Team Invite Settings to the OAUTH Section
-	 * 
+	 *
 	 * @param		array $oauth_settings OAUTH Settings
-	 *                                     
+	 *
 	 * @access		public
 	 * @since		1.1.0
 	 * @return		array Modified OAUTH Settings
 	 */
 	public function add_slack_invites_settings( $oauth_settings ) {
-		
+
 		$slack_invites_settings = array(
 			array(
 				'type' => 'header',
@@ -59,9 +56,9 @@ class EDD_Slack_Invites_Settings {
 				'id' => 'slack_invites_oauth_register',
 			),
 		);
-		
+
 		if ( edd_get_option( 'slack_app_has_client_scope', false ) ) {
-		
+
 			$slack_invites_settings[] = array(
 				'type' => 'textarea',
 				'name' => 'Join Slack Team Text',
@@ -69,14 +66,15 @@ class EDD_Slack_Invites_Settings {
 				'std' => apply_filters( 'edd_slack_app_join_slack_team_default_text', _x( 'Join our Slack Team?', 'Join Slack Team Text Default', 'edd-slack' ) ),
 				'desc' => _x( 'This text is used as the label for the checkbox when someone chooses to join your Slack Team.', 'Join Slack Team Text Description', 'edd-slack' ),
 			);
-			
+
 			$slack_invites_settings[] = array(
 				'type' => 'checkbox',
 				'name' => _x( 'Enable Slack Team Invites for new Customers', 'Customer Slack Invite Checkbox Label', 'edd-slack' ),
 				'id' => 'slack_app_team_invites_customer',
 				'desc' => _x( 'This will add a checkbox to the end of the Purchase Form for Customers to be added to your Slack Team', 'Customer Slack Invite Description' ),
 			);
-			
+
+			$public_channels = $this->get_public_channels();
 			$slack_invites_settings[] = array(
 				'type' => 'select',
 				'name' => _x( 'Channels for Customers', 'Channels for Customers Label', 'edd-slack' ),
@@ -87,7 +85,7 @@ class EDD_Slack_Invites_Settings {
 				),
 				'chosen' => true,
 				'multiple' => true,
-				'options' => $this->get_public_channels(),
+				'options' => $public_channels,
 				'placeholder' => sprintf( _x( 'Just #%s', 'Just #general Channel Invite', 'edd-slack' ), $this->general_channel ),
 				'std' => array(),
 				'desc' => sprintf( _x( 'The <code>#%s</code> Channel is always granted by default. Choose any other additional Channels you would like to auto-invite Customers to.', 'Channels for Customers Description Text', 'edd-slack' ), $this->general_channel ),
@@ -113,80 +111,91 @@ class EDD_Slack_Invites_Settings {
 					),
 					'multiple' => true,
 					'chosen' => true,
-					'options' => $this->get_public_channels(),
+					'options' => $public_channels,
 					'placeholder' => sprintf( _x( 'Just #%s', 'Just #general Channel Invite', 'edd-slack' ), $this->general_channel ),
 					'std' => array(),
 					'desc' => sprintf( _x( 'The <code>#%s</code> Channel is always granted by default. Choose any other additional Channels you would like to auto-invite %s to.', 'Channels for Vendors Description Text', 'edd-slack' ), $this->general_channel, EDD_FES()->helper->get_vendor_constant_name( true, true ) )
 				);
 
 			}
-			
+
 		}
-		
+
 		$oauth_settings = array_merge( $oauth_settings, $slack_invites_settings );
-		
+
 		return $oauth_settings;
-		
+
 	}
-	
+
 	/**
 	 * Returns all Public Slack Channels from the Slack API
-	 * 
-	 * @access		public
-	 * @since		1.1.0
-	 * @return		array Slack Channels
+	 *
+	 * @access  public
+	 * @since   1.1.0
+	 * @return  array Slack Channels
 	 */
 	public function get_public_channels() {
-		
+
+		$channels_array = array();
 		// Don't bother if we aren't granting Client Scope
-		if ( ! edd_get_option( 'slack_app_has_client_scope', false ) ) return array();
-		
-		if ( ! $channels_array = maybe_unserialize( get_transient( 'edd_slack_channels_list' ) ) ) {
-		
-			$result = EDDSLACK()->slack_api->get( 'channels.list' );
-
-			$channels = $result->channels;
-
-			$channels_array = array();
-			foreach ( $channels as $channel ) {
-
-				if ( $channel->is_general ) {
-
-					// If necessary, update our General Channel
-					$this->general_channel = ( $channel->name !== $this->general_channel ) ? $channel->name : $this->general_channel;
-
-					continue; // Skip
-
-				}
-
-				$channels_array[ $channel->id ] = '#' . $channel->name;
-
-			}
-			
-			set_transient( 'edd_slack_channels_list', $channels_array, DAY_IN_SECONDS );
-			
+		if ( ! edd_get_option( 'slack_app_has_client_scope', false ) ) {
+			return $channels_array;
 		}
-		
+		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+			return $channels_array;
+		}
+
+		$transient = maybe_unserialize( get_transient( 'edd_slack_channels_list' ) );
+		if ( $transient ) {
+			return $transient;
+		}
+
+		$oauth_token = edd_get_option( 'slack_app_oauth_token', false );
+		// Don't bother if we don't have an OAUTH Token
+		if ( ! $oauth_token || '-1' == $oauth_token ) {
+			return $channels_array;
+		}
+
+		$result = EDDSLACK()->slack_api->get( 'conversations.list' );
+
+		if ( empty( $result->channels ) ) {
+			return $channels_array;
+		}
+
+		foreach ( $result->channels as $channel ) {
+
+			if ( $channel->is_general ) {
+
+				// If necessary, update our General Channel
+				$this->general_channel = ( $channel->name !== $this->general_channel ) ? $channel->name : $this->general_channel;
+
+				continue; // Skip
+			}
+
+			$channels_array[ $channel->id ] = '#' . $channel->name;
+		}
+
+		set_transient( 'edd_slack_channels_list', $channels_array, DAY_IN_SECONDS );
+
 		return $channels_array;
-		
 	}
-	
+
 	/**
 	 * Updates the #general Channel used in a few places via a Filter
-	 * Since channels can be renamed, if possible we want to use their actual "general" channel name 
-	 * 
+	 * Since channels can be renamed, if possible we want to use their actual "general" channel name
+	 *
 	 * @param		string $general_channel The "general" channel without the hash
-	 *                                                                   
+	 *
 	 * @access		public
 	 * @since		1.1.0
 	 * @return		string The correct "general" channel name
 	 */
 	public function update_general_channel( $general_channel ) {
-		
+
 		return $this->general_channel;
-		
+
 	}
-	
+
 }
 
 $integrate = new EDD_Slack_Invites_Settings();

--- a/core/ssl-only/slack-invites/class-edd-slack-app-invites-settings.php
+++ b/core/ssl-only/slack-invites/class-edd-slack-app-invites-settings.php
@@ -158,7 +158,7 @@ class EDD_Slack_Invites_Settings {
 
 		$result = EDDSLACK()->slack_api->get( 'conversations.list' );
 
-		if ( empty( $result->channels ) ) {
+		if ( empty( $result->channels ) || ! is_array( $result->channels ) ) {
 			return $channels_array;
 		}
 


### PR DESCRIPTION
Fixes #136

Proposed Changes:
1. Removes `get_public_channels` from running on `admin_init` because it's only used to show the list of channels on the settings page.
2. Updates the API call to use `conversations.list` as `channels.list` is deprecated and no longer works at all ([ref](https://api.slack.com/methods/channels.list)).
3. Calls `get_public_channels` just once on the settings screen and assigns the result to a variable (used twice). I did not update the settings arrays formatting although I really wanted to.

Note: you will want to hide the white space changes when reviewing this PR.

To test:
Visit the settings screen and click the "Allow Slack App to Invite Users to your Team" button. On reload, you should see a list of your Slack channels and no PHP errors/warnings.